### PR TITLE
Adds native_modules post_install step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,29 @@
 # 45.x.x (Expo SDK 45)
 
+#### next (45.1.0)
+
+- Adds the ability to disable flipper via an ENV variable in EAS / Expo builds `FLIPPER_DISABLE`
+- Adds a post install step required by Flipper for native modules
+
+#### 45.0.0
+
 - Revised version to match latest Expo SDK. No plugin API changes.
+
+---
 
 # 44.x.x (Expo SDK 44)
 
-## 44.0.2
+#### 44.0.2
 
 - (docs) Adds table of compatible flipper versions [ref](https://github.com/jakobo/expo-community-flipper/issues/6)
 - (docs) Updates published README urls [ref](https://github.com/jakobo/expo-community-flipper/issues/5)
 
-## 44.0.1
+#### 44.0.1
 
 - Resolved idempotency issue with merging flipper into podfiles that contain a use-flipper directive [ref](https://github.com/jakobo/expo-community-flipper/issues/3)
 - (chore) Created an example application that can be used for future triage
 
-## 44.0.0
+#### 44.0.0
 
 - Revised version to match latest Expo SDK. No plugin API changes.
 
@@ -22,12 +31,12 @@
 
 # 43.x.x (Expo SDK 43)
 
-## 43.0.5
+#### 43.0.5
 
 - Allows for specifying a universal flipper version as a string argument to the plugin
 - `build/` directory is committed for transparency
 - Prevents footgun where you could specify Flipper's pods without specifying a Flipper version
 
-## 43.0.1
+#### 43.0.1
 
 - Adds support for specifying individual pod versions

--- a/README.md
+++ b/README.md
@@ -124,3 +124,8 @@ An `/example` directory is built with `expo init example` for each major SDK rel
   }
 }
 ```
+
+# References
+
+- This code is based on the [Flipper Getting Started Guide](https://fbflipper.com/docs/getting-started/react-native/)
+- [Expo Config Plugins](https://docs.expo.dev/guides/config-plugins/)

--- a/plugin/build/withFlipper.js
+++ b/plugin/build/withFlipper.js
@@ -10,6 +10,7 @@ const resolve_from_1 = __importDefault(require("resolve-from"));
 const path_1 = __importDefault(require("path"));
 const fs_1 = __importDefault(require("fs"));
 const EXPO_FLIPPER_TAG = "expo-community-flipper";
+const EXPO_FLIPPER_TAG_POST_INSTALL = "expo-community-flipper-post-install";
 function getConfiguration(options) {
     let flipperVersion = null;
     let iosPods = {};
@@ -62,14 +63,22 @@ function addFlipperToPodfile(contents, options) {
     // so instead, remove the content first, then attempt the insert
     let removeResult;
     let addResult;
+    // remove previous instances for idempotence
     removeResult = (0, generateCode_1.removeContents)({ src: contents, tag: EXPO_FLIPPER_TAG });
+    removeResult = (0, generateCode_1.removeContents)({
+        src: removeResult.contents,
+        tag: EXPO_FLIPPER_TAG_POST_INSTALL,
+    });
+    // insert use_flipper statement
     addResult = (0, generateCode_1.mergeContents)({
         tag: EXPO_FLIPPER_TAG,
         src: removeResult.contents,
         newSrc: `
       # Flipper support successfully added via expo config plugin
       # https://www.npmjs.com/package/expo-community-flipper
-      use_flipper!(${versionString})
+      if !ENV['FLIPPER_DISABLE']
+        use_flipper!(${versionString})
+      end
     `,
         anchor: /# Uncomment to opt-in to using Flipper/,
         offset: -1,
@@ -77,7 +86,24 @@ function addFlipperToPodfile(contents, options) {
     });
     // couldn't remove and couldn't add. Treat the operation as failed
     if (!addResult.didMerge) {
-        throw new Error("Cannot add Flipper to the project's ios/Podfile because it's malformed. Please report this with a copy of your project Podfile. You can generate this with the `expo prebuild` command.");
+        throw new Error("Cannot add use_flipper to the project's ios/Podfile. Please report this with a copy of your project Podfile. You can generate this with the `expo prebuild` command.");
+    }
+    // insert post_install statement inside the post_install loop
+    addResult = (0, generateCode_1.mergeContents)({
+        tag: EXPO_FLIPPER_TAG,
+        src: addResult.contents,
+        newSrc: `
+      # Flipper support successfully added via expo config plugin
+      # https://www.npmjs.com/package/expo-community-flipper
+      flipper_post_install(installer)
+    `,
+        anchor: /post_install do \|installer\|/,
+        offset: 1,
+        comment: "#",
+    });
+    // couldn't remove and couldn't add. Treat the operation as failed
+    if (!addResult.didMerge) {
+        throw new Error("Cannot add flipper_post_install to the project's ios/Podfile. Please report this with a copy of your project Podfile. You can generate this with the `expo prebuild` command.");
     }
     return addResult.contents;
 }

--- a/plugin/build/withFlipper.js
+++ b/plugin/build/withFlipper.js
@@ -10,7 +10,6 @@ const resolve_from_1 = __importDefault(require("resolve-from"));
 const path_1 = __importDefault(require("path"));
 const fs_1 = __importDefault(require("fs"));
 const EXPO_FLIPPER_TAG = "expo-community-flipper";
-const EXPO_FLIPPER_TAG_POST_INSTALL = "expo-community-flipper-post-install";
 function getConfiguration(options) {
     let flipperVersion = null;
     let iosPods = {};
@@ -63,22 +62,14 @@ function addFlipperToPodfile(contents, options) {
     // so instead, remove the content first, then attempt the insert
     let removeResult;
     let addResult;
-    // remove previous instances for idempotence
     removeResult = (0, generateCode_1.removeContents)({ src: contents, tag: EXPO_FLIPPER_TAG });
-    removeResult = (0, generateCode_1.removeContents)({
-        src: removeResult.contents,
-        tag: EXPO_FLIPPER_TAG_POST_INSTALL,
-    });
-    // insert use_flipper statement
     addResult = (0, generateCode_1.mergeContents)({
         tag: EXPO_FLIPPER_TAG,
         src: removeResult.contents,
         newSrc: `
       # Flipper support successfully added via expo config plugin
       # https://www.npmjs.com/package/expo-community-flipper
-      if !ENV['FLIPPER_DISABLE']
-        use_flipper!(${versionString})
-      end
+      use_flipper!(${versionString})
     `,
         anchor: /# Uncomment to opt-in to using Flipper/,
         offset: -1,
@@ -86,24 +77,7 @@ function addFlipperToPodfile(contents, options) {
     });
     // couldn't remove and couldn't add. Treat the operation as failed
     if (!addResult.didMerge) {
-        throw new Error("Cannot add use_flipper to the project's ios/Podfile. Please report this with a copy of your project Podfile. You can generate this with the `expo prebuild` command.");
-    }
-    // insert post_install statement inside the post_install loop
-    addResult = (0, generateCode_1.mergeContents)({
-        tag: EXPO_FLIPPER_TAG,
-        src: addResult.contents,
-        newSrc: `
-      # Flipper support successfully added via expo config plugin
-      # https://www.npmjs.com/package/expo-community-flipper
-      flipper_post_install(installer)
-    `,
-        anchor: /post_install do \|installer\|/,
-        offset: 1,
-        comment: "#",
-    });
-    // couldn't remove and couldn't add. Treat the operation as failed
-    if (!addResult.didMerge) {
-        throw new Error("Cannot add flipper_post_install to the project's ios/Podfile. Please report this with a copy of your project Podfile. You can generate this with the `expo prebuild` command.");
+        throw new Error("Cannot add Flipper to the project's ios/Podfile because it's malformed. Please report this with a copy of your project Podfile. You can generate this with the `expo prebuild` command.");
     }
     return addResult.contents;
 }

--- a/plugin/src/withFlipper.ts
+++ b/plugin/src/withFlipper.ts
@@ -140,7 +140,9 @@ export function addFlipperToPodfile(contents: string, options: flipperConfig) {
     newSrc: `
       # Flipper support successfully added via expo config plugin
       # https://www.npmjs.com/package/expo-community-flipper
-      flipper_post_install(installer)
+      if !ENV['FLIPPER_DISABLE']
+        flipper_post_install(installer)
+      end
     `,
     anchor: /post_install do \|installer\|/,
     offset: 1,

--- a/plugin/src/withFlipper.ts
+++ b/plugin/src/withFlipper.ts
@@ -135,7 +135,7 @@ export function addFlipperToPodfile(contents: string, options: flipperConfig) {
 
   // insert post_install statement inside the post_install loop
   addResult = mergeContents({
-    tag: EXPO_FLIPPER_TAG,
+    tag: EXPO_FLIPPER_TAG_POST_INSTALL,
     src: addResult.contents,
     newSrc: `
       # Flipper support successfully added via expo config plugin


### PR DESCRIPTION
This fixes an issue from #10 where a new post_install step is missing for more recent versions of Flipper. It _should_ be backwards compatible after reading the docs.

Because this introduces more code to a podfile, it's a full PR instead of just a commit, with the goal of getting a few more eyes on it.