### PR TITLE
fix: Support Expo SDK 47

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@commitlint/config-conventional": "^15.0.0",
     "husky": "^7.0.4",
     "lint-staged": "^12.1.2",
-    "prettier": "^2.5.0",
+    "prettier": "^2.5.1",
     "release-it": "*",
     "release-it-yarn-workspaces": "^2.0.1"
   },

--- a/plugin/build/constants.js
+++ b/plugin/build/constants.js
@@ -12,6 +12,6 @@ exports.IOS_URN_ARG_ANCHOR = /:fabric_enabled => flags\[:fabric_enabled\],/;
 /** In a Podfile, this regex tells us the :production arg is already there */
 exports.IOS_HAS_PRODUCTION_ARG = /use_react_native!\([\s\S]*:production\s+=>/gm;
 /** In a Podfile, this regex tells us the :flipper_configuration arg is already there */
-exports.IOS_HAS_FLIPPER_ARG = /use_react_native!\([\s\S]*:flipper_configuration\s+=>/gm;
+exports.IOS_HAS_FLIPPER_ARG = /use_react_native!\([\s\S]*^\s*:flipper_configuration\s+=>/gm;
 /** In a Podfile, this regex detects if use_frameworks is enabled. It also serves as our anchor */
 exports.IOS_USE_FRAMEWORKS_STATEMENT = /[\s*]use_frameworks!/gm;

--- a/plugin/build/withFlipper.ios.d.ts
+++ b/plugin/build/withFlipper.ios.d.ts
@@ -1,3 +1,4 @@
 import { ExpoConfig } from "@expo/config-types";
 import { FlipperConfig } from "./types";
 export declare function withFlipperIOS(config: ExpoConfig, cfg: FlipperConfig): ExpoConfig;
+export declare function updatePodfileContents(contents: string, cfg: FlipperConfig): string;

--- a/plugin/src/__tests__/withFlipper.ios-test.ts
+++ b/plugin/src/__tests__/withFlipper.ios-test.ts
@@ -1,0 +1,73 @@
+import { updatePodfileContents } from "../withFlipper.ios";
+
+describe(updatePodfileContents, () => {
+  it("should update expo sdk 46 podfile", () => {
+    const contents = `
+  use_react_native!(
+    :path => config[:reactNativePath],
+    :hermes_enabled => flags[:hermes_enabled] || podfile_properties['expo.jsEngine'] == 'hermes',
+    :fabric_enabled => flags[:fabric_enabled],
+    # An absolute path to your application root.
+    :app_path => "#{Dir.pwd}/.."
+  )`;
+    expect(
+      updatePodfileContents(contents, {
+        version: "0.999.0",
+        ios: { enabled: true },
+        android: { enabled: true },
+      })
+    ).toMatchInlineSnapshot(`
+      "
+        use_react_native!(
+          :path => config[:reactNativePath],
+          :hermes_enabled => flags[:hermes_enabled] || podfile_properties['expo.jsEngine'] == 'hermes',
+          :fabric_enabled => flags[:fabric_enabled],
+      # @generated begin expo-community-flipper-urn - expo prebuild (DO NOT MODIFY) sync-0d6c393415c155009dbe3271effb1563fab482d2
+          # Flipper arguments generated from app.json
+          :flipper_configuration => ENV['FLIPPER_DISABLE'] == \\"1\\" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled([\\"Debug\\"], { 'Flipper' => '0.999.0' }),
+      # @generated end expo-community-flipper-urn
+          # An absolute path to your application root.
+          :app_path => \\"#{Dir.pwd}/..\\"
+        )"
+    `);
+  });
+
+  it("should update expo sdk 47 podfile", () => {
+    const contents = `
+  use_react_native!(
+    :path => config[:reactNativePath],
+    :hermes_enabled => podfile_properties['expo.jsEngine'] == 'hermes',
+    :fabric_enabled => flags[:fabric_enabled],
+    # An absolute path to your application root.
+    :app_path => "#{Pod::Config.instance.installation_root}/..",
+    #
+    # Uncomment to opt-in to using Flipper
+    # Note that if you have use_frameworks! enabled, Flipper will not work
+    # :flipper_configuration => !ENV['CI'] ? FlipperConfiguration.enabled : FlipperConfiguration.disabled,
+  )`;
+    expect(
+      updatePodfileContents(contents, {
+        version: "0.999.0",
+        ios: { enabled: true },
+        android: { enabled: true },
+      })
+    ).toMatchInlineSnapshot(`
+      "
+        use_react_native!(
+          :path => config[:reactNativePath],
+          :hermes_enabled => podfile_properties['expo.jsEngine'] == 'hermes',
+          :fabric_enabled => flags[:fabric_enabled],
+      # @generated begin expo-community-flipper-urn - expo prebuild (DO NOT MODIFY) sync-0d6c393415c155009dbe3271effb1563fab482d2
+          # Flipper arguments generated from app.json
+          :flipper_configuration => ENV['FLIPPER_DISABLE'] == \\"1\\" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled([\\"Debug\\"], { 'Flipper' => '0.999.0' }),
+      # @generated end expo-community-flipper-urn
+          # An absolute path to your application root.
+          :app_path => \\"#{Pod::Config.instance.installation_root}/..\\",
+          #
+          # Uncomment to opt-in to using Flipper
+          # Note that if you have use_frameworks! enabled, Flipper will not work
+          # :flipper_configuration => !ENV['CI'] ? FlipperConfiguration.enabled : FlipperConfiguration.disabled,
+        )"
+    `);
+  });
+});

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -17,7 +17,7 @@ export const IOS_HAS_PRODUCTION_ARG =
 
 /** In a Podfile, this regex tells us the :flipper_configuration arg is already there */
 export const IOS_HAS_FLIPPER_ARG =
-  /use_react_native!\([\s\S]*:flipper_configuration\s+=>/gm;
+  /use_react_native!\([\s\S]*^\s*:flipper_configuration\s+=>/gm;
 
 /** In a Podfile, this regex detects if use_frameworks is enabled. It also serves as our anchor */
 export const IOS_USE_FRAMEWORKS_STATEMENT = /[\s*]use_frameworks!/gm;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9819,7 +9819,7 @@ __metadata:
     "@commitlint/config-conventional": ^15.0.0
     husky: ^7.0.4
     lint-staged: ^12.1.2
-    prettier: ^2.5.0
+    prettier: ^2.5.1
     release-it: "*"
     release-it-yarn-workspaces: ^2.0.1
   languageName: unknown
@@ -16433,12 +16433,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.5.0":
-  version: 2.5.0
-  resolution: "prettier@npm:2.5.0"
+"prettier@npm:^2.5.1":
+  version: 2.7.1
+  resolution: "prettier@npm:2.7.1"
   bin:
     prettier: bin-prettier.js
-  checksum: aad1b35b73e7c14596d389d90977a83dad0db689ba5802a0ef319c357b7867f55b885db197972aa6a56c30f53088c9f8e0d7f7930ae074c275a4e9cbe091d21d
+  checksum: 55a4409182260866ab31284d929b3cb961e5fdb91fe0d2e099dac92eaecec890f36e524b4c19e6ceae839c99c6d7195817579cdffc8e2c80da0cb794463a748b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

expo sdk 47 introduced a breaking change to Podfile: https://github.com/expo/expo/blob/d6508e5a49f97dc133324cf79783d6dba418d286/templates/expo-template-bare-minimum/ios/Podfile#L27-L30
the change will cause the expo-community-flipper config plugin to throw the error when prebuilding:

```
✖ Config sync failed
Error: [ios.dangerous]: withIosDangerousBaseMod: Cannot add flipper arguments to the project's ios/Podfile. Please report this with a copy of your project Podfile. You can generate this with the `expo prebuild` command.
Error: [ios.dangerous]: withIosDangerousBaseMod: Cannot add flipper arguments to the project's ios/Podfile. Please report this with a copy of your project Podfile. You can generate this with the `expo prebuild` command.
    at /Users/kudo/sdk47/node_modules/expo-community-flipper/build/withFlipper.ios.js:120:23
    at action (/Users/kudo/sdk47/node_modules/expo-community-flipper/node_modules/@expo/config-plugins/build/plugins/withMod.js:235:29)
    at interceptingMod (/Users/kudo/sdk47/node_modules/expo-community-flipper/node_modules/@expo/config-plugins/build/plugins/withMod.js:126:27)
    at action (/Users/kudo/sdk47/node_modules/@expo/config-plugins/build/plugins/withMod.js:240:14)
    at async interceptingMod (/Users/kudo/sdk47/node_modules/@expo/config-plugins/build/plugins/withMod.js:126:21)
    at async interceptingMod (/Users/kudo/sdk47/node_modules/@expo/config-plugins/build/plugins/withMod.js:126:21)
    at async interceptingMod (/Users/kudo/sdk47/node_modules/@expo/config-plugins/build/plugins/withMod.js:126:21)
    at async interceptingMod (/Users/kudo/sdk47/node_modules/@expo/config-plugins/build/plugins/withMod.js:126:21)
    at async action (/Users/kudo/sdk47/node_modules/@expo/config-plugins/build/plugins/createBaseMod.js:71:21)
    at async interceptingMod (/Users/kudo/sdk47/node_modules/@expo/config-plugins/build/plugins/withMod.js:126:21)
```

# How

mainly update the `IOS_HAS_FLIPPER_ARG` regular expression to exclude the commented ` # :flipper_configuration`
this pr also added some unit test. the jest `toMatchInlineSnapshot` having some error as https://github.com/facebook/jest/issues/12112, updating prettier did the trick.

# Test Plan

### Unit Test

```
 PASS  src/__tests__/withFlipper.ios-test.ts
  updatePodfileContents
    ✓ should update expo sdk 46 podfile
    ✓ should update expo sdk 47 podfile
```

### Manual Test

```sh
$ EXPO_BETA=1 yarn create expo-app -t blank@sdk-47 sdk47
$ cd sdk47
$ yarn add expo-community-flipper
# add the plugin in app.json
$ npx expo prebuild --clean --no-install

# patch the _node_modules/expo-community-flipper/build/constants.js_ regular expression
$ npx expo prebuild --clean --no-install
```